### PR TITLE
feat: fuzzy ingredient matching via Damerau-Levenshtein (distance ≤ 2)

### DIFF
--- a/backend/src/RecipeAId.Core/Services/RecipeMatchingService.cs
+++ b/backend/src/RecipeAId.Core/Services/RecipeMatchingService.cs
@@ -5,6 +5,10 @@ namespace RecipeAId.Core.Services;
 
 public class RecipeMatchingService(IRecipeRepository recipeRepo) : IRecipeMatchingService
 {
+    private const double ExactMatchScore = 1.0;
+    private const double FuzzyMatchScore = 0.8;
+    private const int    FuzzyMaxDistance = 2;
+
     public async Task<IEnumerable<IngredientSearchResultDto>> FindByIngredientsAsync(
         IEnumerable<string> ingredientNames,
         int minMatch = 1,
@@ -28,15 +32,34 @@ public class RecipeMatchingService(IRecipeRepository recipeRepo) : IRecipeMatchi
                     .Select(ri => ri.Name)
                     .ToList();
 
-                var matched = recipeIngredientNames.Intersect(requested).ToList();
-                var missing = recipeIngredientNames.Except(requested).ToList();
-                var total   = recipeIngredientNames.Count;
+                var matched     = new List<string>();
+                var missing     = new List<string>();
+                double matchScore = 0.0;
+                int total       = recipeIngredientNames.Count;
 
-                return (Recipe: r, Matched: matched, Missing: missing, Total: total);
+                foreach (var storedName in recipeIngredientNames)
+                {
+                    if (requested.Contains(storedName))
+                    {
+                        matched.Add(storedName);
+                        matchScore += ExactMatchScore;
+                    }
+                    else if (requested.Any(req => DamerauLevenshtein(storedName, req) <= FuzzyMaxDistance))
+                    {
+                        matched.Add(storedName);
+                        matchScore += FuzzyMatchScore;
+                    }
+                    else
+                    {
+                        missing.Add(storedName);
+                    }
+                }
+
+                return (Recipe: r, Matched: matched, Missing: missing, Total: total, MatchScore: matchScore);
             })
             .Where(x => x.Matched.Count >= minMatch)
-            .OrderByDescending(x => x.Matched.Count)
-            .ThenByDescending(x => x.Total > 0 ? (double)x.Matched.Count / x.Total : 0d)
+            .OrderByDescending(x => x.MatchScore)
+            .ThenByDescending(x => x.Total > 0 ? x.MatchScore / x.Total : 0d)
             .Take(limit)
             .Select(x => new IngredientSearchResultDto(
                 new RecipeSummaryDto(x.Recipe.Id, x.Recipe.Title, x.Recipe.CreatedAt, x.Total, x.Recipe.BookTitle),
@@ -45,5 +68,32 @@ public class RecipeMatchingService(IRecipeRepository recipeRepo) : IRecipeMatchi
                 x.Matched,
                 x.Missing))
             .ToList();
+    }
+
+    private static int DamerauLevenshtein(string s, string t)
+    {
+        int sLen = s.Length, tLen = t.Length;
+        if (Math.Abs(sLen - tLen) > FuzzyMaxDistance)
+            return FuzzyMaxDistance + 1;
+
+        var d = new int[sLen + 1, tLen + 1];
+        for (int i = 0; i <= sLen; i++) d[i, 0] = i;
+        for (int j = 0; j <= tLen; j++) d[0, j] = j;
+
+        for (int i = 1; i <= sLen; i++)
+        {
+            for (int j = 1; j <= tLen; j++)
+            {
+                int cost = s[i - 1] == t[j - 1] ? 0 : 1;
+                d[i, j] = Math.Min(
+                    Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1),
+                    d[i - 1, j - 1] + cost);
+
+                if (i > 1 && j > 1 && s[i - 1] == t[j - 2] && s[i - 2] == t[j - 1])
+                    d[i, j] = Math.Min(d[i, j], d[i - 2, j - 2] + cost);
+            }
+        }
+
+        return d[sLen, tLen];
     }
 }

--- a/backend/tests/RecipeAId.Tests/Services/RecipeMatchingServiceTests.cs
+++ b/backend/tests/RecipeAId.Tests/Services/RecipeMatchingServiceTests.cs
@@ -169,4 +169,64 @@ public class RecipeMatchingServiceTests
         Assert.Single(result);
         Assert.Equal(1, result[0].MatchedIngredientCount);
     }
+
+    // ── Fuzzy matching ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task FindByIngredients_FuzzyMatch_TypoWithinThreshold()
+    {
+        // "tomatoe" is distance 1 from "tomato" — should match
+        _recipeRepo.Setup(r => r.GetAllAsync(null, default))
+            .ReturnsAsync([MakeRecipe(1, "Salad", "tomato")]);
+
+        var result = (await _sut.FindByIngredientsAsync(["tomatoe"])).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].MatchedIngredientCount);
+        Assert.Contains("tomato", result[0].MatchedIngredients);
+    }
+
+    [Fact]
+    public async Task FindByIngredients_FuzzyMatch_Transposition()
+    {
+        // "tmoato" — transposition of adjacent characters in "tomato", distance 2
+        _recipeRepo.Setup(r => r.GetAllAsync(null, default))
+            .ReturnsAsync([MakeRecipe(1, "Salad", "tomato")]);
+
+        var result = (await _sut.FindByIngredientsAsync(["tmoato"])).ToList();
+
+        Assert.Single(result);
+        Assert.Equal(1, result[0].MatchedIngredientCount);
+    }
+
+    [Fact]
+    public async Task FindByIngredients_FuzzyMatch_BeyondThreshold_NoMatch()
+    {
+        // "apple" vs "flour" — distance > 2, should not match
+        _recipeRepo.Setup(r => r.GetAllAsync(null, default))
+            .ReturnsAsync([MakeRecipe(1, "Bread", "flour")]);
+
+        var result = (await _sut.FindByIngredientsAsync(["apple"])).ToList();
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task FindByIngredients_ExactMatchRanksAboveFuzzyMatch()
+    {
+        // Recipe A has exact "tomato"; Recipe B has "tomatoe" (fuzzy match).
+        // Both have 1 matched ingredient, but A's score is higher (1.0 vs 0.8).
+        _recipeRepo.Setup(r => r.GetAllAsync(null, default))
+            .ReturnsAsync(
+            [
+                MakeRecipe(1, "Exact Recipe", "tomato"),
+                MakeRecipe(2, "Fuzzy Recipe", "tomatoe"),
+            ]);
+
+        var result = (await _sut.FindByIngredientsAsync(["tomato"])).ToList();
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Exact Recipe", result[0].Recipe.Title);
+        Assert.Equal("Fuzzy Recipe", result[1].Recipe.Title);
+    }
 }

--- a/integration/features/ingredient-search.feature
+++ b/integration/features/ingredient-search.feature
@@ -27,3 +27,9 @@ Feature: Ingredient-based recipe search
     And I click "Find Recipes"
     Then I should see "Garlic Pasta" in the search results
     And "Garlic Pasta" should appear before "Garlic Bread" in the results
+
+  Scenario: Fuzzy match tolerates a typo in an ingredient name
+    When I navigate to the ingredient search page
+    And I add ingredient chip "garlc"
+    And I click "Find Recipes"
+    Then I should see "Garlic Pasta" in the search results


### PR DESCRIPTION
## Summary

- Replaces exact LINQ `Intersect`/`Except` matching in `RecipeMatchingService` with Damerau-Levenshtein (OSA) fuzzy matching, distance threshold ≤ 2
- Exact matches score **1.0**, fuzzy matches score **0.8** — so exact hits rank above fuzzy ones when ingredient counts are tied
- No API surface change; the response DTO is unchanged

## Tests

- 4 new unit tests: typo match, transposition match, beyond-threshold no-match, exact-over-fuzzy ranking
- 1 new BDD scenario: `"garlc"` typed in the search box still finds "Garlic Pasta"
- All 62 backend unit tests pass; all 3 Python sidecar test suites pass; frontend build passes

## Test plan

- [x] Push triggers CI — BDD Docker stack runs the new scenario and all existing ingredient-search scenarios
- [ ] Manually test on the ingredient search page: type a deliberate typo and confirm results appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)